### PR TITLE
IndexedSeq instead of Iterator in NearestNeighborIterator [Priority Queue Serialization Error]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /buildSrc/build
 out
 spark-warehouse
+/metastore_db
+derby.log

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -8,7 +8,7 @@ subprojects {
   // Specify Jar versions here instead of within gradle.properties
   // This will provide overriding ability for internal builds
   tasks.withType(Jar) {
-    version '1.0.0'
+    version '1.0.1'
   }
 
   repositories {

--- a/scanns/src/main/scala/com/linkedin/nn/model/LSHNearestNeighborSearchModel.scala
+++ b/scanns/src/main/scala/com/linkedin/nn/model/LSHNearestNeighborSearchModel.scala
@@ -286,15 +286,9 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
           // logStats(TaskContext.getPartitionId(), itemVectors, hashBuckets)
           new NearestNeighborIterator(hashBuckets.valuesIterator, itemVectors, k)
         }
-      }.aggregateByKey(zero, $(numOutputPartitions))(seqOp, combOp).flatMap{ x => x._2.iterator().map(z => (x._1, z._1, z._2)) }
-      //.groupByKey()
-      //.mapValues { candidateIter =>
-      //  val topN = new TopNQueue(k)
-      //  candidateIter.flatten.foreach(topN.enqueue(_))
-      //  topN.iterator()
-      //}
-      //.flatMap{ x => x._2.map(z => (x._1, z._1, z._2)) }
-      //.repartition($(numOutputPartitions))
+      }
+      .aggregateByKey(zero, $(numOutputPartitions))(seqOp, combOp)
+      .flatMap{ x => x._2.iterator().map(z => (x._1, z._1, z._2)) }
   }
 
   /**

--- a/scanns/src/main/scala/com/linkedin/nn/model/LSHNearestNeighborSearchModel.scala
+++ b/scanns/src/main/scala/com/linkedin/nn/model/LSHNearestNeighborSearchModel.scala
@@ -54,11 +54,11 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
     */
   private[model] class NearestNeighborIterator(bucketsIt: Iterator[Array[mutable.ArrayBuffer[ItemId]]],
                                 itemVectors: mutable.Map[ItemId, Vector],
-                                numNearestNeighbors: Int) extends Iterator[(ItemId, Iterator[ItemIdDistancePair])]
+                                numNearestNeighbors: Int) extends Iterator[(ItemId, IndexedSeq[ItemIdDistancePair])]
     with Serializable {
 
     // this will be the next element that the iterator returns on a call to next()
-    private var nextResult: Option[(ItemId, Iterator[ItemIdDistancePair])] = None
+    private var nextResult: Option[(ItemId, IndexedSeq[ItemIdDistancePair])] = None
 
     // this is the current tuple in the bucketsIt iterator that is being scanned
     private var currentTuple = if (bucketsIt.hasNext) Some(bucketsIt.next) else None
@@ -77,7 +77,7 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
                 .map(c => (c, distance.compute(itemVectors(c), itemVectors(x(0)(currentIndex)))))
                 .foreach(queue.enqueue(_))
               if (queue.nonEmpty()) {
-                nextResult = Some((x(0)(currentIndex), queue.iterator()))
+                nextResult = Some((x(0)(currentIndex), queue.iterator().toIndexedSeq))
                 done = true
               }
               currentIndex += 1
@@ -98,7 +98,7 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
 
     override def hasNext: Boolean = nextResult.isDefined
 
-    override def next(): (ItemId, Iterator[ItemIdDistancePair]) = {
+    override def next(): (ItemId, IndexedSeq[ItemIdDistancePair]) = {
       if (hasNext) {
         val ret = nextResult.get
         populateNext()

--- a/scanns/src/main/scala/com/linkedin/nn/utils/TopNQueue.scala
+++ b/scanns/src/main/scala/com/linkedin/nn/utils/TopNQueue.scala
@@ -6,65 +6,7 @@ package com.linkedin.nn.utils
 
 import com.linkedin.nn.Types.{ItemId, ItemIdDistancePair}
 
-import scala.collection.{mutable, immutable}
-
-import scala.collection.JavaConverters._
-import java.util.PriorityQueue
-import java.util.Comparator
-
-/**
-  *
-  */
-class pq[A](maxCapacity: Int, itemComparator: Comparator[A]) extends PriorityQueue[A](maxCapacity, itemComparator){
-  def toSet: immutable.Set[A] = this.toArray.map(x => x.asInstanceOf[A]).toSet
-  def reverseIterator: Iterator[A] = this.iterator.asScala.toList.reverseIterator
-  def nonEmpty: Boolean = if(this.size() == 0) false else true
-  def enqueue(elems: A*): Unit = {
-    elems.foreach(e => this.add(e))
-  }
-  def dequeue(): A = this.poll()
-  def head: A = this.peek()
-}
-
-class TopNQueue(maxCapacity: Int) extends Serializable{
-
-  val ItemComparator: Comparator[ItemIdDistancePair] = new Comparator[ItemIdDistancePair](){
-    override def compare(item1: ItemIdDistancePair, item2: ItemIdDistancePair): Int = {
-      val diff: Double = item2._2 - item1._2
-      if(diff > 0) return 1 else if(diff < 0) return -1 else return 0
-    }
-  }
-
-  val priorityQ: pq[ItemIdDistancePair] = new pq[ItemIdDistancePair](maxCapacity, ItemComparator)
-  val elements: mutable.HashSet[ItemId] = mutable.HashSet[ItemId]() // for deduplication
-
-  /**
-    * Enqueue elements in the queue
-    * @param elems The elements to enqueue
-    */
-  def enqueue(elems: ItemIdDistancePair*): this.type = {
-    elems.foreach { x =>
-      if (!elements.contains(x._1)) {
-        if (priorityQ.size < maxCapacity) {
-          priorityQ.enqueue(x)
-          elements.add(x._1)
-        } else {
-          if (priorityQ.head._2 > x._2) {
-            elements.remove(priorityQ.dequeue()._1)
-            priorityQ.enqueue(x)
-            elements.add(x._1)
-          }
-        }
-      }
-    }
-    this
-  }
-
-  def nonEmpty(): Boolean = priorityQ.nonEmpty
-
-  def iterator(): Iterator[ItemIdDistancePair] = priorityQ.reverseIterator
-}
-
+import scala.collection.mutable
 
 /**
   * This is a simple wrapper around the scala [[mutable.PriorityQueue]] that allows it to only hold a fixed number of
@@ -75,7 +17,7 @@ class TopNQueue(maxCapacity: Int) extends Serializable{
   *
   * @param maxCapacity max number of elements the queue will hold
   */
-class TopNQueue_original(maxCapacity: Int) extends Serializable {
+class TopNQueue(maxCapacity: Int) extends Serializable {
 
   val priorityQ: mutable.PriorityQueue[ItemIdDistancePair] =
     mutable.PriorityQueue[ItemIdDistancePair]()(Ordering.by[ItemIdDistancePair, Double](_._2))

--- a/scanns/src/main/scala/com/linkedin/nn/utils/TopNQueue.scala
+++ b/scanns/src/main/scala/com/linkedin/nn/utils/TopNQueue.scala
@@ -6,7 +6,65 @@ package com.linkedin.nn.utils
 
 import com.linkedin.nn.Types.{ItemId, ItemIdDistancePair}
 
-import scala.collection.mutable
+import scala.collection.{mutable, immutable}
+
+import scala.collection.JavaConverters._
+import java.util.PriorityQueue
+import java.util.Comparator
+
+/**
+  *
+  */
+class pq[A](maxCapacity: Int, itemComparator: Comparator[A]) extends PriorityQueue[A](maxCapacity, itemComparator){
+  def toSet: immutable.Set[A] = this.toArray.map(x => x.asInstanceOf[A]).toSet
+  def reverseIterator: Iterator[A] = this.iterator.asScala.toList.reverseIterator
+  def nonEmpty: Boolean = if(this.size() == 0) false else true
+  def enqueue(elems: A*): Unit = {
+    elems.foreach(e => this.add(e))
+  }
+  def dequeue(): A = this.poll()
+  def head: A = this.peek()
+}
+
+class TopNQueue(maxCapacity: Int) extends Serializable{
+
+  val ItemComparator: Comparator[ItemIdDistancePair] = new Comparator[ItemIdDistancePair](){
+    override def compare(item1: ItemIdDistancePair, item2: ItemIdDistancePair): Int = {
+      val diff: Double = item2._2 - item1._2
+      if(diff > 0) return 1 else if(diff < 0) return -1 else return 0
+    }
+  }
+
+  val priorityQ: pq[ItemIdDistancePair] = new pq[ItemIdDistancePair](maxCapacity, ItemComparator)
+  val elements: mutable.HashSet[ItemId] = mutable.HashSet[ItemId]() // for deduplication
+
+  /**
+    * Enqueue elements in the queue
+    * @param elems The elements to enqueue
+    */
+  def enqueue(elems: ItemIdDistancePair*): this.type = {
+    elems.foreach { x =>
+      if (!elements.contains(x._1)) {
+        if (priorityQ.size < maxCapacity) {
+          priorityQ.enqueue(x)
+          elements.add(x._1)
+        } else {
+          if (priorityQ.head._2 > x._2) {
+            elements.remove(priorityQ.dequeue()._1)
+            priorityQ.enqueue(x)
+            elements.add(x._1)
+          }
+        }
+      }
+    }
+    this
+  }
+
+  def nonEmpty(): Boolean = priorityQ.nonEmpty
+
+  def iterator(): Iterator[ItemIdDistancePair] = priorityQ.reverseIterator
+}
+
 
 /**
   * This is a simple wrapper around the scala [[mutable.PriorityQueue]] that allows it to only hold a fixed number of
@@ -17,7 +75,7 @@ import scala.collection.mutable
   *
   * @param maxCapacity max number of elements the queue will hold
   */
-class TopNQueue(maxCapacity: Int) extends Serializable {
+class TopNQueue_original(maxCapacity: Int) extends Serializable {
 
   val priorityQ: mutable.PriorityQueue[ItemIdDistancePair] =
     mutable.PriorityQueue[ItemIdDistancePair]()(Ordering.by[ItemIdDistancePair, Double](_._2))


### PR DESCRIPTION
There seemed to have been an issue with concurrency when returning the Iterator in the NearestNeighborIterator class inside of LSHNearestNeighborSearchModel.scala.

Iterator[(ItemId, Iterator[ItemIdDistancePair])] was changed to Iterator[(ItemId, IndexedSeq[ItemIdDistancePair])]. The iterator within the iterator is not serialized and causing a problem with the groupByKey in the getAllNearestNeighbors function. What I think was happening is that during the groupByKey the iterator within the iterator was pointing to a location in memory on a particular node, but when that iterator is copied to another node during the groupByKey it is then pointing to a random position in memory not where one expects.

As a bonus I also rewrote the groupByKey as aggregateByKey, as an aggregate would be more efficient in this case than a groupByKey. I have not done any benchmarking, but from my experience have found aggregateByKey to be more efficient.

Code compiled with ./gradlew build and passed all tests.