### PR TITLE
IndexedSeq instead of Iterator in NearestNeighborIterator [Priority Queue Serialization Error]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /buildSrc/build
 out
 spark-warehouse
+/metastore_db
+derby.log

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -8,7 +8,7 @@ subprojects {
   // Specify Jar versions here instead of within gradle.properties
   // This will provide overriding ability for internal builds
   tasks.withType(Jar) {
-    version '1.0.0'
+    version '1.0.1'
   }
 
   repositories {

--- a/scanns/src/main/scala/com/linkedin/nn/model/LSHNearestNeighborSearchModel.scala
+++ b/scanns/src/main/scala/com/linkedin/nn/model/LSHNearestNeighborSearchModel.scala
@@ -54,11 +54,11 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
     */
   private[model] class NearestNeighborIterator(bucketsIt: Iterator[Array[mutable.ArrayBuffer[ItemId]]],
                                 itemVectors: mutable.Map[ItemId, Vector],
-                                numNearestNeighbors: Int) extends Iterator[(ItemId, Iterator[ItemIdDistancePair])]
+                                numNearestNeighbors: Int) extends Iterator[(ItemId, IndexedSeq[ItemIdDistancePair])]
     with Serializable {
 
     // this will be the next element that the iterator returns on a call to next()
-    private var nextResult: Option[(ItemId, Iterator[ItemIdDistancePair])] = None
+    private var nextResult: Option[(ItemId, IndexedSeq[ItemIdDistancePair])] = None
 
     // this is the current tuple in the bucketsIt iterator that is being scanned
     private var currentTuple = if (bucketsIt.hasNext) Some(bucketsIt.next) else None
@@ -77,7 +77,7 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
                 .map(c => (c, distance.compute(itemVectors(c), itemVectors(x(0)(currentIndex)))))
                 .foreach(queue.enqueue(_))
               if (queue.nonEmpty()) {
-                nextResult = Some((x(0)(currentIndex), queue.iterator()))
+                nextResult = Some((x(0)(currentIndex), queue.iterator().toIndexedSeq))
                 done = true
               }
               currentIndex += 1
@@ -98,7 +98,7 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
 
     override def hasNext: Boolean = nextResult.isDefined
 
-    override def next(): (ItemId, Iterator[ItemIdDistancePair]) = {
+    override def next(): (ItemId, IndexedSeq[ItemIdDistancePair]) = {
       if (hasNext) {
         val ret = nextResult.get
         populateNext()
@@ -261,6 +261,9 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
     } else {
       explodeData(transform(candidatePool)).partitionBy(hashPartitioner)
     }
+    val zero: TopNQueue = new TopNQueue(k)
+    def seqOp(U: TopNQueue, V: IndexedSeq[ItemIdDistancePair]): TopNQueue = {U.enqueue(V:_*); U}
+    def combOp(X: TopNQueue, Y: TopNQueue): TopNQueue = {X.enqueue(Y.iterator().toSeq:_*); X}
     srcItemsExploded.zipPartitions(candidatePoolExploded) {
         case (srcIt, candidateIt) => {
           val itemVectors = mutable.Map[ItemId, Vector]()
@@ -284,14 +287,8 @@ abstract class LSHNearestNeighborSearchModel[T <: LSHNearestNeighborSearchModel[
           new NearestNeighborIterator(hashBuckets.valuesIterator, itemVectors, k)
         }
       }
-      .groupByKey()
-      .mapValues { candidateIter =>
-        val topN = new TopNQueue(k)
-        candidateIter.flatten.foreach(topN.enqueue(_))
-        topN.iterator()
-      }
-      .flatMap{ x => x._2.map(z => (x._1, z._1, z._2)) }
-      .repartition($(numOutputPartitions))
+      .aggregateByKey(zero, $(numOutputPartitions))(seqOp, combOp)
+      .flatMap{ x => x._2.iterator().map(z => (x._1, z._1, z._2)) }
   }
 
   /**


### PR DESCRIPTION
There seemed to have been an issue with concurrency when returning the Iterator in the NearestNeighborIterator class inside of LSHNearestNeighborSearchModel.scala.

Iterator[(ItemId, Iterator[ItemIdDistancePair])] was changed to Iterator[(ItemId, IndexedSeq[ItemIdDistancePair])]. The iterator within the iterator is not serialized and causing a problem with the groupByKey in the getAllNearestNeighbors function. What I think was happening is that during the groupByKey the iterator within the iterator was pointing to a location in memory on a particular node, but when that iterator is copied to another node during the groupByKey it is then pointing to a random position in memory not where one expects.

As a bonus I also rewrote the groupByKey as aggregateByKey, as an aggregate would be more efficient in this case than a groupByKey. I have not done any benchmarking, but from my experience have found aggregateByKey to be more efficient.

Code compiled with ./gradlew build and passed all tests.